### PR TITLE
fix: Update CODEOWNERS to valid org member @cnsfeir

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Not Cumplo audit gate
-* @cnsfeir-reviewer
+* @cnsfeir


### PR DESCRIPTION
## Summary
- Replace `@cnsfeir-reviewer` (non-existent GitHub user, not a member of `cristobal-sfeir-inc`) with `@cnsfeir` in `.github/CODEOWNERS`.
- This makes the code-owner gate functional: previously, all CODEOWNERS entries resolved to a ghost user, meaning PRs could merge without any real review.

## Implementation notes
- Single-line change: `* @cnsfeir-reviewer` → `* @cnsfeir`.
- Applied identically across all 11 org repos as part of NOT-33 (CODEOWNERS non-functional security fix).
- No functional logic changed — only the reviewer identity is corrected.

## Verification
- Confirmed `@cnsfeir` is the org admin (owner) of `cristobal-sfeir-inc`.
- After merge, GitHub will enforce code-owner approval from `@cnsfeir` on all PRs.

## Risk and rollback
- No rollback risk: reverting to `@cnsfeir-reviewer` would restore the non-functional state.
- Once branch-protection rules are enabled (NOT-33 action 2), merges without `@cnsfeir` approval will be blocked.