### PR TITLE
ci: Use PUBLISH_SA variable for WIF lint auth

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,53 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  lint:
+    name: Lint & type-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: "2.4.1"
+          virtualenvs-in-project: true
+
+      - name: Cache virtualenv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-py3.13-${{ hashFiles('poetry.lock') }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ vars.WIF_PROVIDER }}
+          service_account: ${{ vars.PUBLISH_SA }}
+
+      - name: Configure Poetry auth for Artifact Registry
+        run: poetry config http-basic.cumplo-pypi oauth2accesstoken "$(gcloud auth print-access-token)"
+
+      - name: Install dependencies
+        run: poetry install --no-interaction
+
+      - name: Lint
+        run: make lint


### PR DESCRIPTION
**Why:** Org-level \`PUBLISH_SA\` replaces the never-created \`READ_SA\`; the SA can both read and publish \`cumplo-common\`, making it the correct credential for the WIF lint auth step. This adds the lint workflow so CI can install from Artifact Registry and run \`make lint\` on PRs.
**Issue:** Refs NOT-37
**Notes for reviewer:** Single-file addition of \`.github/workflows/lint.yml\`. Confirm \`vars.WIF_PROVIDER\` and \`vars.PUBLISH_SA\` are set at org level (done in NOT-36) before merging. No Python changes; YAML syntax is valid.